### PR TITLE
Use .__str__ rather than .message to print errors.

### DIFF
--- a/bin/1pass
+++ b/bin/1pass
@@ -9,5 +9,5 @@ import onepassword.cli
 try:
     onepassword.cli.CLI().run()
 except Exception as e:
-    sys.stderr.write("1pass: Error: %s\n" % e.message)
+    sys.stderr.write("1pass: Error: %s\n" % e)
     sys.exit(1)


### PR DESCRIPTION
This helps because IOError does not assign `message', but **str** prints
both the path and the error that occurred.
